### PR TITLE
一部ユーザでFacebookログインのできない不具合の解消

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,15 +6,21 @@ class User < ApplicationRecord
 
   def self.find_for_oauth(auth)
     user = User.where(uid: auth.uid, provider: auth.provider).first
+    email_register = auth.extra.raw_info.email ? auth.extra.raw_info.email : User.dummy_email(auth)
       unless user
         user = User.create(
           uid:      auth.uid,
           provider: auth.provider,
-          email:    auth.extra.raw_info.email,
+          email:    email_register,
           password: Devise.friendly_token[0, 20],
           gender:   auth.extra.raw_info.gender
           )
       end
     user
+  end
+
+  private
+  def self.dummy_email(auth)
+    "#{auth.uid}-#{auth.provider}@example.com"
   end
 end


### PR DESCRIPTION
# 今回の不具合の原因
- 一部ユーザでログインした時にメールアドレスの登録がなく、正常にログインができなかった

# やったこと
- userの作成時にFacebookにemailの登録がなければ、ダミーのemailアドレスを作成しそちらで登録するようにした