### PR TITLE
投稿の際の内容の文字数を制限した

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -28,7 +28,7 @@ class PostsController < ApplicationController
       flash[:notice] = "悩みを投稿しました"
       redirect_to("/posts/#{@post.id}")
     else
-      flash[:notice] = "タイトルと内容は必須入力です"
+      flash[:notice] = "タイトルと内容は必須入力です。タイトルは40文字以下、内容は40文字以上の制限があります。"
       render("posts/new")
     end
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   has_many :replies
-  validates :title, {presence: true,length: {maximum: 40 }}
-  validates :content, {presence: true}
+  validates :title, {presence: true, length: {maximum: 40 }}
+  validates :content, {presence: true, length: {minimum: 40 }}
   validates :user_id, {presence: true}
 
   # onewaylove=片想い, together=交際中, date=デート, present=プレゼント, lovevision=恋愛観,

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -5,39 +5,33 @@
 <meta name="viewport" content="width=device-width">
 </head>-->
 
-
-
 <div id = "toukou_syousai">
-<div class="main">
-  <h2>悩みを投稿する</h2>
-  <!--<ul>
-<li class="center"><a href="/"><img src="/back5.jpg" width="20" height="30" class="logo"></a></li>
-<li class = " section">悩みを投稿する</li>
-</ul>-->
- <div class="main posts-new">
-   <div class="container">
-     <p class="form-heading"></p>
-     <%= form_tag("/posts", method: :post) do %>
-       <div class="form-group">
-
-         <div class="form-title">
-           <label class="title">タイトル</label>
-           <textarea name="title" class="round_off form-control" rows="2" cols="60"></textarea>
-         </div>
-
-         <div class="form-body">
-           <label class="title">内容</label>
-           <textarea name="content" class="round_off form-control" rows="5" cols="60"></textarea>
-         </div>
-
-         <%= render partial: "category_form", :locals => { post: @post } %>
-
-         <li class="contribution"> <input type="submit" value="投稿"></li>
+  <div class="main">
+    <h2>悩みを投稿する</h2>
+      <!--<ul>
+    <li class="center"><a href="/"><img src="/back5.jpg" width="20" height="30" class="logo"></a></li>
+    <li class = " section">悩みを投稿する</li>
+    </ul>-->
+     <div class="main posts-new">
+       <div class="container">
+         <p class="form-heading"></p>
+         <%= form_tag("/posts", method: :post) do %>
+           <div class="form-group">
+             <div class="form-title">
+               <label class="title">タイトル</label>
+               <textarea name="title" class="round_off form-control" rows="2" cols="60"><%= @post.title %></textarea>
+             </div>
+             <div class="form-body">
+               <label class="title">内容</label>
+               <textarea name="content" class="round_off form-control" rows="5" cols="60"> <%= @post.content%></textarea>
+             </div>
+             <%= render partial: "category_form", :locals => { post: @post } %>
+             <li class="contribution"> <input type="submit" value="投稿"></li>
+           </div>
+         <% end %>
        </div>
-     <% end %>
+     </div>
    </div>
- </div>
- </div>
  </div>
 
 <!--<%= link_to("投稿内容がうまく書けない方はこちら","/")%>-->


### PR DESCRIPTION
# やったこと
- 悩みの相談の内容が40文字以上でないと投稿できないようにした
- 文字数の制限による投稿失敗時に投稿画面に表示するようにした
- 投稿失敗時にも入力内容が消えないようにした